### PR TITLE
[WIP] Sketch for a wrapper for `Distribution` that enables batching and GPU sampling

### DIFF
--- a/src/batch.jl
+++ b/src/batch.jl
@@ -71,8 +71,6 @@ function Random.rand(rng::AbstractRNG, d::BatchDistributionWrapper{D, T}) where 
     return x
 end
 
-rand(gpu(d))
-
 function Distributions.logpdf(d::BatchDistributionWrapper{D, T}, x::AbstractArray) where {D, T}
     dists = D.(d.parameters...)
     return reshape(map(logpdf, dists, x), d.batch_shape)


### PR DESCRIPTION
I started this PR trying to address the lack of GPU support for distributions, as initially mentioned in issue [#12](https://github.com/TuringLang/NormalizingFlows.jl/issues/12). There are two strategies discussed to resolve this issue:

1. Create a specific GPU version for each `Distribution`.
2. Develop a wrapper for `Distribution`s that can work on GPU.

The latter approach, being less code-intensive, forms the basis of this PR.

The concept of shapes for distributions used in the `Tensorflow Probability`, `PyMC`, and `Pyro` packages is employed here. These include `Event Shape`, `Sample Shape` and `Batch Shape`. `Event Shape` is essentially `length(d::Distribution)`. `Sample Shape` is explicit when call `rand` function. 'Batch Shape' is particularly significant for this implementation.

`BatchDistributionWrapper` is used for dispatch to specific implementatino of functions, these function may target GPU for high performance. By using the type of parameter arrays as surrogates for the device type (`Array` for CPU and `CuArray` for GPU), we can facilitate dispatching based on the `Distribution` type and the relevant device type.

Here's the way `BatchDistributionWrapper` is defined:

```julia
struct BatchDistributionWrapper{D<:Distribution, T<:AbstractArray}
    distribution::Type{D}
    parameters::NTuple{M, T} where M
    batch_shape::NTuple{N, Int} where N
end
@functor BatchDistributionWrapper (parameters, )

function BatchDistributionWrapper(dist::Symbol, params, batch_shape=())
    if any((iszero∘ndims), params) # if any of the parameters is a scalar, return the Distribution
        return getfield(Distributions, dist)(params...)
    end

    @assert isdefined(Distributions, dist) "Distribution $dist is not defined"
    
    @assert all(map(x->eltype(x) != Any, params)) "all parameters should have concrete element type"
    @assert all(map(x->eltype(x) == eltype(params[1]), params)) "all parameters should have the same element type"

    D = getfield(Distributions, dist)
    return BatchDistributionWrapper{D, eltype(params)}(D, params, batch_shape)
end
```

`rand` function can be implemented as

```julia
function Random.rand(rng::AbstractRNG, d::BatchDistributionWrapper{D, T}) where {D<:Normal, T<:CuArray}
    μ, σ = d.parameters
    x = similar(μ)
    CUDA.rand!(x)
    x .*= σ
    x .+= μ
    return x
end
```

Test example for `BatchDistributionWrapper`:

```julia
d = BatchDistributionWrapper(:Normal, (rand(2, 2, 1), rand(2, 2, 1)), (2, 2))
rand(gpu(d))
```
returns
```julia
2×2×1 CuArray{Float32, 3, CUDA.Mem.DeviceBuffer}:
[:, :, 1] =
 0.377751  0.249488
 0.769026  0.433008
```

## Some further considerations

- The constructor as currently implemented is somewhat simplistic, and there are several areas where it could potentially be improved:
    - **Implicit Broadcasting**: Consider a distribution `my_dist` that requires two parameters for construction. If the first parameter is a scalar and the second is a vector, calls such as `my_dist(rand(2), rand(2, 2))` and `my_dist(rand(2, 1), rand(2, 2))` should both be valid and produce identical results. As of now, our implementation only supports cases where all parameters have the same number of dimensions.
    - **Batch Shape Specification**: It may be possible to eliminate the necessity of specifying the batch shape. This, however, would require prior knowledge of the size of the inputs to the distribution constructor.

* Similar concept could also be expanded to include `bijectors`, and `transformed distributions`